### PR TITLE
Distribution entry is via tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ end
 gem "sass-rails", "~> 4.0.3"
 gem "autoprefixer-rails"
 gem "bootstrap-sass"
+gem "bootstrap-tagsinput-rails"
 gem "uglifier", ">= 1.3.0"
 gem "coffee-rails", "~> 4.0.0"
 gem "therubyrhino"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,8 @@ GEM
     bootstrap-sass (3.3.5)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.2.19)
+    bootstrap-tagsinput-rails (0.4.2.1)
+      railties (>= 3.1)
     builder (3.2.3)
     cancancan (1.15.0)
     celluloid (0.17.3)
@@ -344,6 +346,7 @@ DEPENDENCIES
   better_errors (~> 1.0)
   binding_of_caller
   bootstrap-sass
+  bootstrap-tagsinput-rails
   cancancan (~> 1.10)
   coffee-rails (~> 4.0.0)
   comma (~> 4.1)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -60,3 +60,4 @@
 //= require tabs
 //
 //= require jquery-dateformat.min.js
+//= require bootstrap-tagsinput

--- a/app/assets/stylesheets/application.css.scss.erb
+++ b/app/assets/stylesheets/application.css.scss.erb
@@ -45,6 +45,7 @@ $staging-color: #6699cc;
 @import "tree-placement";
 @import "environment";
 @import "bootstrap-editable";
+@import "bootstrap-tagsinput";
 
 // possibly this should not be here, instead the tree search results page should declare it as a dependency
 /*@import "tree-extras/tree";*/
@@ -684,4 +685,8 @@ a.disabled {
   100% {
     opacity: 0.5;
   }
+}
+
+.bootstrap-tagsinput {
+  width: 100%;
 }

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -244,6 +244,12 @@ class TreesController < ApplicationController
     render "update_parent_error.js"
   end
 
+  def typeahead_on_distribution
+    distributions = Distribution::AsTypeahead::ForDescription.new(params[:term])
+    render json: distributions.results
+  end
+
+
   private
 
   # todo determine if this should be removed.

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+#   Copyright 2018 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+class Distribution < ActiveRecord::Base
+  self.table_name = "distribution"
+  self.primary_key = "id"
+  self.sequence_name = "nsl_global_seq"
+
+  validates :description, presence: true
+  validates :region, presence: true
+  validates :sort_order, presence: true
+
+  def self.display_order
+    Distribution.order(sort_order: :asc)
+  end
+
+  def doubtfully_naturalised?
+    is_doubtfully_naturalised
+  end
+
+  def extinct?
+    is_extinct
+  end
+
+  def native?
+    is_native
+  end
+
+  def naturalised?
+    is_naturalised
+  end
+
+end

--- a/app/models/distribution/as_typeahead/for_description.rb
+++ b/app/models/distribution/as_typeahead/for_description.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+#   Copyright 2018 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# Return array of instances based primarily on full_name
+# but additionally on reference.year.
+#
+# Take a string of search terms like "podolepis jaceoides 1957".
+# Match the year component against reference.year and the
+# non-year component against name.full_name in a join
+# on instance.
+# Can also handle strings like:
+#   '1957 podolepis jaceoides'
+#   'podolepis 1957 jaceoides'
+#
+# But disordered name fragments, like
+#   'jac podolepis'
+# do not work because the text part
+# is not currently broken into independently
+# matched fragments.
+#
+class Distribution::AsTypeahead::ForDescription
+  attr_reader :results
+  COLUMNS = " id, description, region, is_doubtfully_naturalised, is_extinct, is_native, is_naturalised "
+  SEARCH_LIMIT = 20
+
+  def initialize(term)
+    @term = term&.downcase
+    query()
+  end
+
+  def query()
+    @results = Distribution.display_order
+    if (@term)
+      @results = @results.select { | dist | dist.description.downcase.include?(@term)}
+    end
+  end
+end

--- a/app/views/distribution/index.html.erb
+++ b/app/views/distribution/index.html.erb
@@ -1,0 +1,6 @@
+<h1>Distribution</h1>
+<h2>API</h2>
+<dl>
+  <dt>list</dt>
+  <dd>JSON list of distributions</dd>
+</dl>

--- a/app/views/instances/workspace/_draft_placement.html.erb
+++ b/app/views/instances/workspace/_draft_placement.html.erb
@@ -40,11 +40,7 @@
     <dd>
       <%= form_tag({controller: 'trees', action: 'update_distribution'}, {method: :post, remote: true}) do %>
         <%= hidden_field_tag("update_distribution[element_link]", @tree_version_element.element_link) %>
-        <% if @tree_version_element.distribution.blank? %>
-          <%= render partial: "trees/add_distribution", locals: {tree_version_element: @tree_version_element} %>
-        <% else %>
-          <%= render partial: "trees/update_distribution", locals: {tree_version_element: @tree_version_element} %>
-        <% end %>
+        <%= render partial: "trees/update_distribution", locals: {tree_version_element: @tree_version_element} %>
       <% end %>
       <div id="tree_distribution_message" class="message-container inline hidden"></div>
     </dd>

--- a/app/views/instances/workspace/_new_placement.html.erb
+++ b/app/views/instances/workspace/_new_placement.html.erb
@@ -31,7 +31,7 @@
           </dd>
           <dt><%= @working_draft.distribution_key %></dt>
           <dd>
-            <%= text_area_tag("place_name[distribution]", '', title: 'Edit distribution', rows: 2, class: 'form-control') %>
+            <%= text_area_tag("place_name[distribution]", '', title: 'Edit distribution', rows: 2, class: 'form-control', 'data-role' => 'tagsinput') %>
             <button type="button"
                     class="btn btn-warning clear-area"
                     onclick="$('#place_name_distribution').val('');">Clear distribution
@@ -55,6 +55,15 @@
       <div id="placement-error-message-container" class="message-container error hidden"></div>
     <% end %>
   </div>
+    <script type="application/javascript">
+      var distributions = [ <%= Distribution.display_order.collect {| d | "{ id: #{d.id}, label: '#{d.description}'" }.join(', ') %> ];
+      $(function() {
+          var dist_text = $("#place_name_distribution");
+          distributions.each(function (i, d) {
+              dist_test.tagsinput('add', d.label);
+          });
+      });
+    </script>
 <% end %>
 
 

--- a/app/views/trees/_add_distribution.html.erb
+++ b/app/views/trees/_add_distribution.html.erb
@@ -1,4 +1,4 @@
-<%= text_area_tag("update_distribution[distribution]", @tree_version_element.distribution, escaped: false, title: 'Edit distribution', rows: 2, class: 'form-control', tabindex: increment_tab_index) %>
+<%= text_field_tag("update_distribution[distribution]", @tree_version_element.distribution, escaped: false, title: 'Edit distribution', rows: 2, class: 'form-control', tabindex: increment_tab_index) %>
 
 <button type="submit"
         id="update_distribution_btn"

--- a/app/views/trees/_update_distribution.html.erb
+++ b/app/views/trees/_update_distribution.html.erb
@@ -1,5 +1,58 @@
-<%= text_area_tag("update_distribution[distribution]", @tree_version_element.distribution, title: 'Edit distribution', rows: 2, class: 'form-control', tabindex: increment_tab_index) %>
+<%= text_field_tag("update_distribution[distribution]", @tree_version_element.distribution, title: 'Edit distribution', class: 'form-control', tabindex: increment_tab_index, 'data-role' => 'tagsinput') %>
+<script type="application/javascript">
+  $(function () {
+      var distributions = new Bloodhound({
+          datumTokenizer: Bloodhound.tokenizers.obj.whitespace('description'),
+          queryTokenizer: Bloodhound.tokenizers.whitespace,
+          prefetch: window.relative_url_root + '/trees/typeahead_on_distribution',
+          limit: 5
+      });
+      distributions.initialize();
 
+      function checkDistributionItem(item) {
+          return distributions.index.datums.some(function (elt) {
+              return elt.description == item;
+          });
+      }
+
+      function distributionValid(control) {
+          var items = control.tagsinput('items');
+          var valid = items.length == 0 || items.every(checkDistributionItem);
+          $("#update_distribution_btn").attr('disabled', !valid);
+      }
+
+      function distributionValidEvent(event) {
+          distributionValid($(this));
+      }
+
+      var dist_text = $("#update_distribution_distribution");
+      dist_text.tagsinput({
+          tagClass: function (item) {
+              return checkDistributionItem(item) ? 'label label-info' : 'label label-danger label-important';
+          },
+          typeaheadjs: {
+              name: 'distributions',
+              displayKey: 'description',
+              valueKey: 'description',
+              source: distributions.ttAdapter()
+          }
+      });
+      dist_text.on('itemAdded', distributionValidEvent);
+      dist_text.on('itemRemoved', distributionValidEvent);
+      distributionValid(dist_text);
+  });
+</script>
+<% if @tree_version_element.distribution.blank? %>
+    <button type="submit"
+            id="update_distribution_btn"
+            class="btn btn-primary left"
+            name="update_distribution[update]"
+            tabindex="<%= increment_tab_index %>"
+            title="Update this distribution"
+            onclick="$('#update_distribution_btn').find('i.fa').addClass('fa-spin');"
+    >Add distribution <i class="fa fa-refresh"></i>
+    </button>
+<% else %>
 <button type="submit"
         id="update_distribution_btn"
         class="btn btn-primary left"
@@ -37,5 +90,6 @@
           onclick="$('#confirm_delete_distribution').hide();$('#update_distribution_btn').show();$('#delete_distribution_btn').prop('disabled', false);$('#confirm_delete_distribution_btn').find('i.fa').removeClass('fa-spin');"
   >Cancel delete
   </button>
-  <% increment_tab_index %>
+<% end %>
+<% increment_tab_index %>
 </div>

--- a/config/changes-2018.yml
+++ b/config/changes-2018.yml
@@ -25,3 +25,8 @@
   :jira_id: '2499'
   :description: |-
     Correct the ordering of instances by page.
+- :date: 21-May-2018
+  :jira_id: '2743'
+  :description: |-
+    Add distribution modelling and interface
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -311,6 +311,11 @@ Rails.application.routes.draw do
         to: "trees#update_synonymy",
         via: :post
 
+  match "trees/typeahead_on_distribution",
+        as: "trees_typeahead_on_distribution",
+        to: "trees#typeahead_on_distribution",
+        via: :get
+
   match "search/reports",
         as: "search_reports",
         to: "search#reports",

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1459,7 +1459,8 @@ CREATE TABLE public.distribution (
   is_extinct                boolean DEFAULT false                                       NOT NULL,
   is_native                 boolean DEFAULT false                                       NOT NULL,
   is_naturalised            boolean DEFAULT false                                       NOT NULL,
-  region                    character varying(10)                                       NOT NULL
+  region                    character varying(10)                                       NOT NULL,
+  sort_order                int DEFAULT 0                                               NOT NULL
 );
 
 --

--- a/test/fixtures/distributions.yml
+++ b/test/fixtures/distributions.yml
@@ -1,0 +1,56 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+qld_native:
+  description: Qld
+  is_doubtfully_naturalised: false
+  is_extinct: false
+  is_native: true
+  is_naturalised: false
+  region: Qld
+  sort_order: 100
+
+nsw_native:
+  description: NSW
+  is_doubtfully_naturalised: false
+  is_extinct: false
+  is_native: true
+  is_naturalised: false
+  region: NSW
+  sort_order: 110
+
+nsw_naturalised:
+  description: NSW (naturalised)
+  is_doubtfully_naturalised: false
+  is_extinct: false
+  is_native: false
+  is_naturalised: true
+  region: NSW
+  sort_order: 1110
+
+qld_naturalised:
+  description: Qld (naturalised)
+  is_doubtfully_naturalised: false
+  is_extinct: false
+  is_native: false
+  is_naturalised: true
+  region: Qld
+  sort_order: 1100
+
+qld_doubtfully_naturalised:
+  description: Qld (?naturalised)
+  is_doubtfully_naturalised: true
+  is_extinct: false
+  is_native: false
+  is_naturalised: false
+  region: Qld
+  sort_order: 2100
+
+qld_extinct:
+  description: Qld (extinct)
+  is_doubtfully_naturalised: false
+  is_extinct: true
+  is_native: false
+  is_naturalised: false
+  region: Qld
+  sort_order: 3100
+

--- a/test/models/distribution_test.rb
+++ b/test/models/distribution_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+#   Copyright 2018 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require 'test_helper'
+
+class DistributionTest < ActiveSupport::TestCase
+  test "display_order" do
+    sorted = Distribution.display_order
+    assert_not_nil sorted
+    assert_equal 6, sorted.size
+    assert_equal "Qld", sorted[0].description
+    assert_equal 'NSW', sorted[1].description
+    assert_equal 'Qld (naturalised)',sorted[2].description
+    assert_equal 'NSW (naturalised)', sorted[3].description
+    assert_equal 'Qld (?naturalised)', sorted[4].description
+    assert_equal 'Qld (extinct)',sorted[5].description
+  end
+
+  test "doubtfully naturalised" do
+    dist = distributions(:qld_native)
+    assert !dist.doubtfully_naturalised?
+    dist = distributions(:qld_doubtfully_naturalised)
+    assert dist.doubtfully_naturalised?
+  end
+
+  test "naturalised" do
+    dist = distributions(:qld_naturalised)
+    assert dist.naturalised?
+    dist = distributions(:qld_doubtfully_naturalised)
+    assert !dist.naturalised?
+  end
+
+  test "native" do
+    dist = distributions(:qld_native)
+    assert dist.native?
+    dist = distributions(:qld_doubtfully_naturalised)
+    assert !dist.native?
+  end
+
+  test "extinct" do
+    dist = distributions(:qld_extinct)
+    assert dist.extinct?
+    dist = distributions(:qld_native)
+    assert !dist.extinct?
+  end
+
+  test "region" do
+    dist = distributions(:qld_native)
+    assert_equal "Qld", dist.region
+    dist = distributions(:qld_naturalised)
+    assert_equal "Qld", dist.region
+  end
+
+end


### PR DESCRIPTION
Using a vocabulary from the  Distribution table. Jira NSL-2743

Uses the tagsinput plugin.
_draft_placement.html.erb now points to _update_distribution rather than separating add/update since they both need to be connected to the tagsinput code. 